### PR TITLE
Refactor theme switch

### DIFF
--- a/frontend/src/components/router-head/router-head.tsx
+++ b/frontend/src/components/router-head/router-head.tsx
@@ -1,5 +1,6 @@
 import { component$ } from '@builder.io/qwik';
 import { useDocumentHead, useLocation } from '@builder.io/qwik-city';
+import { ThemeScript } from './theme-script';
 
 /**
  * The RouterHead component is placed inside of the document `<head>` element.
@@ -14,6 +15,7 @@ export const RouterHead = component$(() => {
 
       <link rel="canonical" href={loc.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta name="color-scheme" content="dark light" />
       <link rel="icon" type="image/png" href="/favicon.png" />
 
       <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -45,6 +47,7 @@ export const RouterHead = component$(() => {
       {head.styles.map((s) => (
         <style {...s.props} dangerouslySetInnerHTML={s.style} />
       ))}
+      <ThemeScript />
     </>
   );
 });

--- a/frontend/src/components/router-head/theme-script.tsx
+++ b/frontend/src/components/router-head/theme-script.tsx
@@ -1,0 +1,13 @@
+import { DARK_THEME, LIGHT_THEME } from '../theme-switcher/theme-switcher';
+
+export const themeStorageKey = 'theme-preference';
+
+export const ThemeScript = () => {
+  const themeScript = `
+        document.firstElementChild
+            .setAttribute('data-theme',
+                localStorage.getItem('${themeStorageKey}') ??
+                (window.matchMedia('(prefers-color-scheme: dark)').matches ? ${DARK_THEME} : ${LIGHT_THEME})
+            )`;
+  return <script dangerouslySetInnerHTML={themeScript} />;
+};

--- a/frontend/src/components/theme-switcher/theme-loader.tsx
+++ b/frontend/src/components/theme-switcher/theme-loader.tsx
@@ -1,0 +1,23 @@
+import { component$, useClientEffect$, useContext } from '@builder.io/qwik';
+import { GlobalStore } from '../../context';
+import {
+  colorSchemeChangeListener,
+  DARK_THEME,
+  getColorPreference,
+  LIGHT_THEME,
+  setPreference,
+} from '../theme-switcher/theme-switcher';
+
+export const ThemeLoader = component$(() => {
+  const globalStore = useContext(GlobalStore);
+
+  useClientEffect$(() => {
+    globalStore.theme = getColorPreference();
+    return colorSchemeChangeListener((isDark) => {
+      globalStore.theme = isDark ? DARK_THEME : LIGHT_THEME;
+      setPreference(globalStore.theme);
+    });
+  });
+
+  return <div data-theme-loader></div>;
+});

--- a/frontend/src/components/waves/waves.tsx
+++ b/frontend/src/components/waves/waves.tsx
@@ -1,15 +1,13 @@
-import { component$, useContext, useStylesScoped$ } from '@builder.io/qwik';
-import { ThemeContext, ThemeStore } from '../../routes/layout';
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
+
+//import { ThemeContext, ThemeStore } from '../../routes/layout';
 import styles from './waves.css?inline';
 
 export const Waves = component$(() => {
   useStylesScoped$(styles);
-  const state: ThemeStore = useContext(ThemeContext) as ThemeStore;
-
-  const fillColor = state.darkMode ? '255,255,255' : '5,122,255';
 
   return (
-    <div className="waves-div">
+    <div className={`waves-div`}>
       <svg
         class="waves"
         xmlns="http://www.w3.org/2000/svg"
@@ -29,28 +27,28 @@ export const Waves = component$(() => {
             xlink:href="#gentle-wave"
             x="48"
             y="0"
-            fill={`rgba(${fillColor},0.7)`}
+            fill={`hsla(var(--w-bg) / 0.7)`}
           />
           <use
             // @ts-expect-error
             xlink:href="#gentle-wave"
             x="48"
             y="3"
-            fill={`rgba(${fillColor},0.5)`}
+            fill={`hsla(var(--w-bg) / 0.5)`}
           />
           <use
             // @ts-expect-error
             xlink:href="#gentle-wave"
             x="48"
             y="5"
-            fill={`rgba(${fillColor},0.3)`}
+            fill={`hsla(var(--w-bg) / 0.3)`}
           />
           <use
             // @ts-expect-error
             xlink:href="#gentle-wave"
             x="48"
             y="7"
-            fill={`rgba(${fillColor},1)`}
+            fill={`hsla(var(--w-bg) / 1)`}
           />
         </g>
       </svg>

--- a/frontend/src/components/waves/waves.tsx
+++ b/frontend/src/components/waves/waves.tsx
@@ -1,13 +1,11 @@
 import { component$, useStylesScoped$ } from '@builder.io/qwik';
-
-//import { ThemeContext, ThemeStore } from '../../routes/layout';
 import styles from './waves.css?inline';
 
 export const Waves = component$(() => {
   useStylesScoped$(styles);
 
   return (
-    <div className={`waves-div`}>
+    <div className="waves-div">
       <svg
         class="waves"
         xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/context.ts
+++ b/frontend/src/context.ts
@@ -1,0 +1,8 @@
+import { createContext } from '@builder.io/qwik';
+import { ThemePreference } from './components/theme-switcher/theme-switcher';
+
+export interface SiteStore {
+  theme: ThemePreference | 'auto';
+}
+
+export const GlobalStore = createContext<SiteStore>('site-store');

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -13,3 +13,12 @@ body {
   text-align: center;
   overflow: hidden;
 }
+
+/* Custom variables for themes */
+[data-theme='dracula'] {
+  --w-bg: 0 0% 100%; /* Wave background */
+}
+
+[data-theme='winter'] {
+  --w-bg: 212 100% 51%; /* Wave background */
+}

--- a/frontend/src/root.tsx
+++ b/frontend/src/root.tsx
@@ -1,10 +1,11 @@
-import { component$ } from '@builder.io/qwik';
+import { component$, useContextProvider, useStore } from '@builder.io/qwik';
 import {
   QwikCity,
   RouterOutlet,
   ServiceWorkerRegister,
 } from '@builder.io/qwik-city';
 import { RouterHead } from './components/router-head/router-head';
+import { GlobalStore, SiteStore } from './context';
 
 import './global.css';
 
@@ -15,6 +16,12 @@ export default component$(() => {
    *
    * Dont remove the `<head>` and `<body>` elements.
    */
+
+  const store = useStore<SiteStore>({
+    theme: 'auto',
+  });
+  useContextProvider(GlobalStore, store);
+
   return (
     <QwikCity>
       <head>

--- a/frontend/src/routes/layout.tsx
+++ b/frontend/src/routes/layout.tsx
@@ -1,33 +1,27 @@
-import {
-  component$,
-  createContext,
-  Slot,
-  useClientEffect$,
-  useContextProvider,
-  useStore,
-} from '@builder.io/qwik';
-import { LOCAL_STORAGE_THEME_KEY } from '../components/theme-switcher/theme-switcher';
+import { component$, Slot } from '@builder.io/qwik';
+import { ThemeLoader } from '~/components/theme-switcher/theme-loader';
 
-export interface ThemeStore {
-  darkMode: boolean;
-}
+// export interface ThemeStore {
+//   darkMode: boolean;
+// }
 
-export const ThemeContext = createContext('theme');
+// export const ThemeContext = createContext('theme');
 
 export default component$(() => {
-  const state = useStore<ThemeStore>({
-    darkMode: true,
-  });
+  // const state = useStore<ThemeStore>({
+  //   darkMode: true,
+  // });
 
-  useContextProvider(ThemeContext, state);
+  // useContextProvider(ThemeContext, state);
 
-  useClientEffect$(() => {
-    state.darkMode = localStorage.getItem(LOCAL_STORAGE_THEME_KEY) === 'true';
-  });
+  // useClientEffect$(() => {
+  //   state.darkMode = localStorage.getItem(LOCAL_STORAGE_THEME_KEY) === 'true';
+  // });
 
   return (
     <>
-      <main data-theme={state.darkMode ? 'dracula' : 'winter'} class="h-screen">
+      <ThemeLoader />
+      <main class="h-screen">
         <section>
           <Slot />
         </section>

--- a/frontend/src/routes/layout.tsx
+++ b/frontend/src/routes/layout.tsx
@@ -1,23 +1,7 @@
 import { component$, Slot } from '@builder.io/qwik';
 import { ThemeLoader } from '~/components/theme-switcher/theme-loader';
 
-// export interface ThemeStore {
-//   darkMode: boolean;
-// }
-
-// export const ThemeContext = createContext('theme');
-
 export default component$(() => {
-  // const state = useStore<ThemeStore>({
-  //   darkMode: true,
-  // });
-
-  // useContextProvider(ThemeContext, state);
-
-  // useClientEffect$(() => {
-  //   state.darkMode = localStorage.getItem(LOCAL_STORAGE_THEME_KEY) === 'true';
-  // });
-
   return (
     <>
       <ThemeLoader />


### PR DESCRIPTION
Fixed the issue causing a 1 second gap between loading the default theme and the preferred theme on refresh.
Now the used theme is based on localStorage value (key: 'theme-preference')
Get preferred color schema from the user media.
Added custom color variables for themes in global.css (Just extend it)
