### PR TITLE
Fix broken repo in github button

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -49,7 +49,7 @@ export default component$(() => {
                     <GithubButton
                       type="Star"
                       user="origranot"
-                      repo="url-shortener"
+                      repo="reduced.to"
                       showCount
                       label="Star"
                     ></GithubButton>


### PR DESCRIPTION
# Description

Github button was pointing to the wrong repository (old name `url-shortener`) it will lead into problems in the future when Github removes the cache history.

I updated it to point the actual repo name