### PR TITLE
Feature multiple layouts

### DIFF
--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,12 +1,13 @@
 import { component$, Slot } from '@builder.io/qwik';
-import MainLayout from '~/layouts/MainLayout';
 
 export default component$(() => {
   return (
-    <>
-      <MainLayout>
+    // Navbar will go here
+    <main>
+      <section>
         <Slot />
-      </MainLayout>
-    </>
+      </section>
+    </main>
+    // Footer will go here
   );
 });

--- a/frontend/src/layouts/NotFoundLayout.tsx
+++ b/frontend/src/layouts/NotFoundLayout.tsx
@@ -1,0 +1,9 @@
+import { component$, Slot } from '@builder.io/qwik';
+
+export default component$(() => {
+  return (
+    <main>
+      <Slot />
+    </main>
+  );
+});

--- a/frontend/src/root.tsx
+++ b/frontend/src/root.tsx
@@ -1,6 +1,7 @@
 import { component$, useContextProvider, useStore } from '@builder.io/qwik';
 import { QwikCity, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
 import { RouterHead } from './components/router-head/router-head';
+import { ThemeLoader } from './components/theme-switcher/theme-loader';
 import { GlobalStore, SiteStore } from './context';
 
 import './global.css';
@@ -25,6 +26,7 @@ export default component$(() => {
         <RouterHead />
       </head>
       <body>
+        <ThemeLoader />
         <RouterOutlet />
         <ServiceWorkerRegister />
       </body>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,6 +7,7 @@ import {
   useStylesScoped$,
 } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
+import animations from '~/assets/css/animations.css?inline';
 import { GithubButton } from '~/components/github-button/github-button';
 import { Loader } from '~/components/loader/loader';
 import { generateQRCode } from '~/components/qr-code/handleQRCode';
@@ -16,7 +17,6 @@ import { ShortenerInput } from '~/components/shortener-input/shortener-input';
 import { ThemeSwitcher } from '~/components/theme-switcher/theme-switcher';
 import { Tooltip } from '~/components/tooltip/tooltip';
 import { Waves } from '~/components/waves/waves';
-import animations from '../assets/css/animations.css?inline';
 import styles from './index.css?inline';
 
 export const InputContext = createContext('input');
@@ -38,136 +38,142 @@ export default component$(() => {
   useContextProvider(InputContext, state);
 
   return (
-    <div class="min-h-screen flex flex-col">
-      <div class="mx-auto container grid grid-cols-12 flex-1">
-        <div class="col-start-2 col-end-12 md:col-start-3 md:col-end-11">
-          <div className="flex flex-col">
-            <div className="flex justify-end my-5">
-              <div className="flex">
-                <div className="grid  flex-grow place-items-center">
-                  <span className="h-5">
-                    <GithubButton
-                      type="Star"
-                      user="origranot"
-                      repo="reduced.to"
-                      showCount
-                      label="Star"
-                    ></GithubButton>
-                  </span>
+    <div className="h-screen overflow-x-hidden overflow-y-auto md:overflow-hidden">
+      <div class="min-h-screen flex flex-col">
+        <div class="mx-auto container grid grid-cols-12 flex-1">
+          <div class="col-start-2 col-end-12 md:col-start-3 md:col-end-11">
+            <div className="flex flex-col">
+              <div className="flex justify-end my-5">
+                <div className="flex">
+                  <div className="grid  flex-grow place-items-center">
+                    <span className="h-5">
+                      <GithubButton
+                        type="Star"
+                        user="origranot"
+                        repo="reduced.to"
+                        showCount
+                        label="Star"
+                      ></GithubButton>
+                    </span>
+                  </div>
+                  <div className="divider divider-horizontal"></div>
+                  <div className="grid  flex-grow place-items-center">
+                    <ThemeSwitcher></ThemeSwitcher>
+                  </div>
                 </div>
-                <div className="divider divider-horizontal"></div>
-                <div className="grid  flex-grow place-items-center">
-                  <ThemeSwitcher></ThemeSwitcher>
+              </div>
+              <article class="prose mx-auto max-w-4xl pb-16">
+                <div class="mx-auto">
+                  <img class="mx-auto" src="logo.png" width="410" height="73" alt="Logo" />
+                </div>
+                <p>
+                  Add your very long <b>URL</b> in the input below and click on the button to make
+                  it shorter
+                </p>
+              </article>
+              <ShortenerInput
+                onKeyUp$={(event) => {
+                  if (event.key.toLowerCase() === 'enter' && state.inputValue.length > 0) {
+                    handleShortener({ state });
+                  }
+                }}
+                onInput$={(event) => (state.inputValue = (event.target as HTMLInputElement).value)}
+                onSubmit$={() => handleShortener({ state })}
+              />
+              <Loader />
+              <div id="result" class="hidden">
+                <p id="error" className="fade-in"></p>
+                <span
+                  id="text"
+                  className="fade-in cursor-pointer"
+                  onClick$={() => copyUrl()}
+                ></span>
+                <div
+                  id="action"
+                  className="hidden btn-group p-4 relative [&>:first-child>.btn]:rounded-l-lg [&>:last-child>.btn]:rounded-r-lg [&>*>.btn]:rounded-none"
+                >
+                  <button
+                    type="button"
+                    title="Copy"
+                    className="btn relative"
+                    onClick$={() => {
+                      copyUrl();
+                      tooltipCopyRef.value = true;
+                    }}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width={1.5}
+                      stroke="currentColor"
+                      className="w-6 h-6"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+                      />
+                    </svg>
+                    <Tooltip label="Copied!" position="bottom" open={tooltipCopyRef}></Tooltip>
+                  </button>
+                  <button
+                    type="button"
+                    title="Open in new tab"
+                    className="btn"
+                    onClick$={() => openLink()}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width={1.5}
+                      stroke="currentColor"
+                      className="w-6 h-6"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    title="QR Code"
+                    className="btn"
+                    onClick$={() => generateQRCode(150)}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width={1.5}
+                      stroke="currentColor"
+                      className="w-6 h-6"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 013.75 9.375v-4.5zM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 01-1.125-1.125v-4.5zM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0113.5 9.375v-4.5z"
+                      />
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M6.75 6.75h.75v.75h-.75v-.75zM6.75 16.5h.75v.75h-.75v-.75zM16.5 6.75h.75v.75h-.75v-.75zM13.5 13.5h.75v.75h-.75v-.75zM13.5 19.5h.75v.75h-.75v-.75zM19.5 13.5h.75v.75h-.75v-.75zM19.5 19.5h.75v.75h-.75v-.75zM16.5 16.5h.75v.75h-.75v-.75z"
+                      />
+                    </svg>
+                  </button>
                 </div>
               </div>
-            </div>
-            <article class="prose mx-auto max-w-4xl pb-16">
-              <div class="mx-auto">
-                <img class="mx-auto" src="logo.png" width="410" height="73" alt="Logo" />
+              <div id="qrcode" className="hidden mx-auto">
+                <QRCode showDownload />
               </div>
-              <p>
-                Add your very long <b>URL</b> in the input below and click on the button to make it
-                shorter
-              </p>
-            </article>
-            <ShortenerInput
-              onKeyUp$={(event) => {
-                if (event.key.toLowerCase() === 'enter' && state.inputValue.length > 0) {
-                  handleShortener({ state });
-                }
-              }}
-              onInput$={(event) => (state.inputValue = (event.target as HTMLInputElement).value)}
-              onSubmit$={() => handleShortener({ state })}
-            />
-            <Loader />
-            <div id="result" class="hidden">
-              <p id="error" className="fade-in"></p>
-              <span id="text" className="fade-in cursor-pointer" onClick$={() => copyUrl()}></span>
-              <div
-                id="action"
-                className="hidden btn-group p-4 relative [&>:first-child>.btn]:rounded-l-lg [&>:last-child>.btn]:rounded-r-lg [&>*>.btn]:rounded-none"
-              >
-                <button
-                  type="button"
-                  title="Copy"
-                  className="btn relative"
-                  onClick$={() => {
-                    copyUrl();
-                    tooltipCopyRef.value = true;
-                  }}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width={1.5}
-                    stroke="currentColor"
-                    className="w-6 h-6"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-                    />
-                  </svg>
-                  <Tooltip label="Copied!" position="bottom" open={tooltipCopyRef}></Tooltip>
-                </button>
-                <button
-                  type="button"
-                  title="Open in new tab"
-                  className="btn"
-                  onClick$={() => openLink()}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width={1.5}
-                    stroke="currentColor"
-                    className="w-6 h-6"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
-                    />
-                  </svg>
-                </button>
-                <button
-                  type="button"
-                  title="QR Code"
-                  className="btn"
-                  onClick$={() => generateQRCode(150)}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width={1.5}
-                    stroke="currentColor"
-                    className="w-6 h-6"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 013.75 9.375v-4.5zM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 01-1.125-1.125v-4.5zM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0113.5 9.375v-4.5z"
-                    />
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M6.75 6.75h.75v.75h-.75v-.75zM6.75 16.5h.75v.75h-.75v-.75zM16.5 6.75h.75v.75h-.75v-.75zM13.5 13.5h.75v.75h-.75v-.75zM13.5 19.5h.75v.75h-.75v-.75zM19.5 13.5h.75v.75h-.75v-.75zM19.5 19.5h.75v.75h-.75v-.75zM16.5 16.5h.75v.75h-.75v-.75z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-            <div id="qrcode" className="hidden mx-auto">
-              <QRCode showDownload />
             </div>
           </div>
         </div>
+        <Waves />
       </div>
-      <Waves />
     </div>
   );
 });

--- a/frontend/src/routes/unknown/layout!.tsx
+++ b/frontend/src/routes/unknown/layout!.tsx
@@ -1,0 +1,10 @@
+import { component$, Slot } from '@builder.io/qwik';
+import NotFoundLayout from '~/layouts/NotFoundLayout';
+
+export default component$(() => {
+  return (
+    <NotFoundLayout>
+      <Slot />
+    </NotFoundLayout>
+  );
+});


### PR DESCRIPTION
# Description
I've reorganized the frontend app to use different layouts depending on the rendered page.
It will help us to easily create new pages based on these new layouts.

Every page of the app (`/`) is now wrapped by `MainLayout`, if we add a Header/Navbar and footer to this layout, it will be rendered in all pages.

If we don't want to use the `MainLayout` in some pages, for example `404`, we can simply add a new layout file on that route, followed by an `!`. Example: `/src/routes/unknown/layout!.tsx`. It will be detected as the very top layout to be used for this page and child pages. Read: https://qwik.builder.io/qwikcity/layout/top/

# Usage
New layouts go under `/layouts` folder. Then you can just import them into the `layout.tsx` files.