### PR TITLE
fix(twitter): used url params and fixed the grammer

### DIFF
--- a/frontend/src/components/home-buttons/actions.tsx
+++ b/frontend/src/components/home-buttons/actions.tsx
@@ -1,14 +1,15 @@
 /**
  * function to share on twitter
  * @param url - the reduced url link
- * @returns
  */
 export function handleShareOnTwitter(url: string) {
   if (!url) return;
 
-  const text = `${encodeURIComponent('My url has just reduced!\nCheck out:')}`;
-  const hashtags = 'reducedto,shortenurl';
+  const params = new URLSearchParams();
+  params.set('text', encodeURIComponent('My URL has just been reduced! 🎉'));
+  params.set('url', url);
+  params.set('hashtags', 'reduced.to,shortenurl');
 
-  const twitterUrl = `https://twitter.com/share?text=${text} &url=${url} &hashtags=${hashtags}`;
+  const twitterUrl = `https://twitter.com/share?${params.toString()}`;
   window.open(twitterUrl, '', 'left=0,top=auto,width=550,height=450');
 }


### PR DESCRIPTION
- Fixed the grammer in the twitter share pop up.
- Used URL params instead of interpolation.