### PR TITLE
fix(twitter): Remove encode of the raw text

### DIFF
--- a/frontend/src/components/home-buttons/actions.tsx
+++ b/frontend/src/components/home-buttons/actions.tsx
@@ -6,9 +6,9 @@ export function handleShareOnTwitter(url: string) {
   if (!url) return;
 
   const params = new URLSearchParams();
-  params.set('text', encodeURIComponent('My URL has just been reduced! 🎉'));
+  params.set('text', 'My URL has just been reduced! 🎉\nCheck it out:');
   params.set('url', url);
-  params.set('hashtags', 'reduced.to,shortenurl');
+  params.set('hashtags', 'reducedto,shortenurl');
 
   const twitterUrl = `https://twitter.com/share?${params.toString()}`;
   window.open(twitterUrl, '', 'left=0,top=auto,width=550,height=450');


### PR DESCRIPTION
- Removed ```encodeURIComponent``` function that caused percent-encoded values