### PR TITLE
Avoid shortening an already short url (#271)

### DIFF
--- a/backend/src/config/config.factory.ts
+++ b/backend/src/config/config.factory.ts
@@ -7,7 +7,7 @@ export const configFactory: ConfigFactory<{ config: IConfiguration }> = () => {
         port: +process.env.APP_PORT || 3000,
       },
       front: {
-        domain: process.env.FRONT_DOMAIN,
+        domain: process.env.FRONT_DOMAIN || 'http://localhost:5173',
       },
       rateLimit: {
         ttl: +process.env.RATE_LIMIT_TTL || 60,

--- a/backend/src/shortener/__mocks__/shortener.service.ts
+++ b/backend/src/shortener/__mocks__/shortener.service.ts
@@ -1,5 +1,0 @@
-export const ShortenerService = jest.fn().mockReturnValue({
-  generateShortUrl: jest.fn(),
-  isShortUrlAvailable: jest.fn(),
-  addUrl: jest.fn(),
-});

--- a/backend/src/shortener/shortener.controller.spec.ts
+++ b/backend/src/shortener/shortener.controller.spec.ts
@@ -1,10 +1,10 @@
+import { AppConfigModule } from './../config/config.module';
+import { AppCacheModule } from './../cache/cache.module';
 import { ShortenerService } from './shortener.service';
 import { ShortenerController } from './shortener.controller';
 import { Test } from '@nestjs/testing';
 import { ShortenerDTO } from './dto';
 import { BadRequestException } from '@nestjs/common';
-
-jest.mock('./shortener.service.ts');
 
 describe('ShortenerController', () => {
   let shortenerController: ShortenerController;
@@ -13,6 +13,7 @@ describe('ShortenerController', () => {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [ShortenerController],
+      imports: [AppConfigModule, AppCacheModule],
       providers: [ShortenerService],
     }).compile();
 

--- a/backend/src/shortener/shortener.controller.ts
+++ b/backend/src/shortener/shortener.controller.ts
@@ -29,8 +29,8 @@ export class ShortenerController {
       parsedUrl = new URL(body.originalUrl);
 
       // Checks if the URL is not already reduced.
-      if (this.shortenerService.isURLAlreadyShortend(body.originalUrl)) {
-        throw new Error('The URL is already shortened by reduced.to');
+      if (this.shortenerService.isUrlAlreadyShortend(body.originalUrl)) {
+        throw new Error('The URL is already shortened...');
       }
     } catch (err: any) {
       throw new BadRequestException({

--- a/backend/src/shortener/shortener.controller.ts
+++ b/backend/src/shortener/shortener.controller.ts
@@ -25,14 +25,13 @@ export class ShortenerController {
   @Post()
   async shortener(@Body() body: ShortenerDTO) {
     let parsedUrl: URL;
-    let isAlreadyShortened: boolean;
-
     try {
       parsedUrl = new URL(body.originalUrl);
 
-      // Checks if the URL is not an already Reduced.to short URL.
-      isAlreadyShortened = this.shortenerService.isURLAlreadyShortend(body.originalUrl);
-      if(isAlreadyShortened) throw new Error('The URL is already shortened by reduced.to')
+      // Checks if the URL is not already a reduced.
+      if(this.shortenerService.isURLAlreadyShortend(body.originalUrl)) {
+          throw new Error('The URL is already shortened by reduced.to')
+      }
 
     } catch (err: any) {
       throw new BadRequestException({

--- a/backend/src/shortener/shortener.controller.ts
+++ b/backend/src/shortener/shortener.controller.ts
@@ -28,11 +28,10 @@ export class ShortenerController {
     try {
       parsedUrl = new URL(body.originalUrl);
 
-      // Checks if the URL is not already a reduced.
-      if(this.shortenerService.isURLAlreadyShortend(body.originalUrl)) {
-          throw new Error('The URL is already shortened by reduced.to')
+      // Checks if the URL is not already reduced.
+      if (this.shortenerService.isURLAlreadyShortend(body.originalUrl)) {
+        throw new Error('The URL is already shortened by reduced.to');
       }
-
     } catch (err: any) {
       throw new BadRequestException({
         status: HttpStatus.BAD_REQUEST,

--- a/backend/src/shortener/shortener.controller.ts
+++ b/backend/src/shortener/shortener.controller.ts
@@ -25,12 +25,19 @@ export class ShortenerController {
   @Post()
   async shortener(@Body() body: ShortenerDTO) {
     let parsedUrl: URL;
+    let isAlreadyShortened: boolean;
+
     try {
       parsedUrl = new URL(body.originalUrl);
+
+      // Checks if the URL is not an already Reduced.to short URL.
+      isAlreadyShortened = this.shortenerService.isURLAlreadyShortend(body.originalUrl);
+      if(isAlreadyShortened) throw new Error('The URL is already shortened by reduced.to')
+
     } catch (err: any) {
       throw new BadRequestException({
         status: HttpStatus.BAD_REQUEST,
-        error: 'URL is invalid',
+        error: err.message || 'URL is invalid',
       });
     }
 

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -1,4 +1,5 @@
 import { AppCacheService } from './../cache/cache.service';
+import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
@@ -21,7 +22,8 @@ export class ShortenerService {
    * @return {Boolean} Returns a boolean
    */
   isURLAlreadyShortend = (shortUrl: string): boolean => {
-    return  (/^(https?:\/\/)?(www\.)?reduced\.to(\/.*)?$/).test(shortUrl)
+    const regex = new RegExp(process.env.FRONT_DOMAIN)
+    return  regex.test(shortUrl)
   }
 
   /**

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -1,5 +1,4 @@
 import { AppCacheService } from './../cache/cache.service';
-import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class ShortenerService {
-  constructor(private readonly appCacheService: AppCacheService) {}
+  constructor(private readonly appCacheService: AppCacheService) { }
 
   /**
    * Return the original url of the specific url.
@@ -14,6 +14,15 @@ export class ShortenerService {
     const originalUrl = await this.appCacheService.get(shortUrl);
     return originalUrl ? originalUrl.toString() : null;
   };
+
+  /**
+   * Checks if the url has already been shortend by a using a Regular Expression.
+   * @param {String} shortUrl The short url
+   * @return {Boolean} Returns a boolean
+   */
+  isURLAlreadyShortend = (shortUrl: string): boolean => {
+    return  (/^(https?:\/\/)?(www\.)?reduced\.to(\/.*)?$/).test(shortUrl)
+  }
 
   /**
    * Generating the short url

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -1,9 +1,13 @@
 import { AppCacheService } from './../cache/cache.service';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class ShortenerService {
-  constructor(private readonly appCacheService: AppCacheService) { }
+  constructor(
+    private readonly appCacheService: AppCacheService,
+    private readonly configService: ConfigService
+  ) {}
 
   /**
    * Return the original url of the specific url.
@@ -21,9 +25,9 @@ export class ShortenerService {
    * @return {Boolean} Returns a boolean
    */
   isURLAlreadyShortend = (shortUrl: string): boolean => {
-    const regex = new RegExp(process.env.FRONT_DOMAIN)
-    return  regex.test(shortUrl)
-  }
+    const domainRegex = new RegExp(this.configService.get<string>('config.front.domain'));
+    return domainRegex.test(shortUrl);
+  };
 
   /**
    * Generating the short url

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -1,12 +1,12 @@
 import { AppCacheService } from './../cache/cache.service';
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { AppConfigService } from 'src/config/config.service';
 
 @Injectable()
 export class ShortenerService {
   constructor(
     private readonly appCacheService: AppCacheService,
-    private readonly configService: ConfigService
+    private readonly appConfigService: AppConfigService
   ) {}
 
   /**
@@ -25,7 +25,7 @@ export class ShortenerService {
    * @return {Boolean} Returns a boolean
    */
   isURLAlreadyShortend = (shortUrl: string): boolean => {
-    const domainRegex = new RegExp(this.configService.get<string>('config.front.domain'));
+    const domainRegex = new RegExp(this.appConfigService.getConfig().front.domain);
     return domainRegex.test(shortUrl);
   };
 

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -22,9 +22,9 @@ export class ShortenerService {
   /**
    * Checks if the url has already been shortend by a using a Regular Expression.
    * @param {String} shortUrl The short url
-   * @return {Boolean} Returns a boolean
+   * @returns {Boolean} Returns a boolean
    */
-  isURLAlreadyShortend = (shortUrl: string): boolean => {
+  isUrlAlreadyShortend = (shortUrl: string): boolean => {
     const domainRegex = new RegExp(this.appConfigService.getConfig().front.domain);
     return domainRegex.test(shortUrl);
   };

--- a/backend/src/shortener/shortener.service.ts
+++ b/backend/src/shortener/shortener.service.ts
@@ -1,6 +1,6 @@
 import { AppCacheService } from './../cache/cache.service';
 import { Injectable } from '@nestjs/common';
-import { AppConfigService } from 'src/config/config.service';
+import { AppConfigService } from '../config/config.service';
 
 @Injectable()
 export class ShortenerService {


### PR DESCRIPTION
Hi @origranot #271 

Added the backend block for the already-shortened URLs.
You can check the code, I'm available on discord if you wanna change something.

As far as the frontend concern there is no special message for that error (there is in the backend), so it is still 'Invalid URL...' message on the frontend.