### PR TITLE
fix(entry.express.tsx): override default clientConn on Qwik

### DIFF
--- a/apps/frontend/src/routes/[...urlId]/index.tsx
+++ b/apps/frontend/src/routes/[...urlId]/index.tsx
@@ -1,15 +1,13 @@
 import { RequestHandler } from '@builder.io/qwik-city';
 
-export const onGet: RequestHandler = async ({ params: { urlId }, redirect, request }) => {
+export const onGet: RequestHandler = async ({ params: { urlId }, redirect, clientConn }) => {
   let originalUrl: string;
-
-  const headers = {
-    'x-forwarded-for': request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || '',
-  };
 
   try {
     const res = await fetch(`${process.env.API_DOMAIN}/api/v1/shortener/${urlId}`, {
-      headers,
+      headers: {
+        'x-forwarded-for': clientConn.ip || '',
+      },
     });
     originalUrl = await res.text();
 


### PR DESCRIPTION
feat(entry.express.tsx): add support for getting client IP address from request headers in getClientConn function
fix(index.tsx): remove unnecessary headers object and use clientConn.ip directly in fetch request