### PR TITLE
Improve SEO on register page #456 

### DIFF
--- a/apps/frontend/src/routes/register/index.tsx
+++ b/apps/frontend/src/routes/register/index.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore } from '@builder.io/qwik';
-import { Form, globalAction$, RequestHandler, z, zod$ } from '@builder.io/qwik-city';
+import { DocumentHead, Form, globalAction$, RequestHandler,z, zod$ } from '@builder.io/qwik-city';
 import { setTokensAsCookies, validateAccessToken } from '../../shared/auth.service';
 
 interface RegisterStore {
@@ -173,3 +173,45 @@ export default component$(() => {
     </div>
   );
 });
+
+export const head: DocumentHead = {
+  title: 'Reduced.to | Register',
+  meta: [
+    {
+      name: 'title',
+      content: 'Reduced.to | Register',
+    },
+    {
+      name: 'description',
+      content: 'Reduced.to | Create your Reduced.to account to manage your shorten links.',
+    },
+    {
+      property: 'og:type',
+      content: 'website',
+    },
+    {
+      property: 'og:url',
+      content: 'https://reduced.to/register',
+    },
+    {
+      property: 'og:title',
+      content: 'Reduced.to | Register',
+    },
+    {
+      property: 'og:description',
+      content: 'Reduced.to | Create your Reduced.to account to manage your shorten links.',
+    },
+    {
+      property: 'twitter:card',
+      content: 'summary',
+    },
+    {
+      property: 'twitter:title',
+      content: 'Reduced.to | Register',
+    },
+    {
+      property: 'twitter:description',
+      content: 'Reduced.to | Create your Reduced.to account to manage your shorten links.',
+    },
+  ],
+};


### PR DESCRIPTION
Fixes #456 

Improve SEO on register page by setting up title and metadata inside the head tag.

I've also set a description, do not hesitate to tell me if changes are needed.

<img width="374" alt="Screenshot 2023-09-27 at 19 04 32" src="https://github.com/origranot/reduced.to/assets/4435536/247e5cc0-dadd-4550-9d57-a23b52d68951">

---

By the way nice project ! :+1: 

Discovered it with the hacktoberfest.
