### PR TITLE
fix: Typos on decorator errors

### DIFF
--- a/apps/backend/src/shared/decorators/sortable/sortable.decorator.ts
+++ b/apps/backend/src/shared/decorators/sortable/sortable.decorator.ts
@@ -32,7 +32,7 @@ export class SortableConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage(args: ValidationArguments) {
-    return `${args.property} is already exists!`;
+    return `${args.property} already exists!`;
   }
 }
 

--- a/apps/backend/src/shared/decorators/unique/unique.decorator.spec.ts
+++ b/apps/backend/src/shared/decorators/unique/unique.decorator.spec.ts
@@ -59,7 +59,7 @@ describe('UniqueDecorator', () => {
       constraints: ['User'],
       property: 'email',
     } as TestValidationArguments);
-    expect(defaultMessage).toBe('email is already exists!');
+    expect(defaultMessage).toBe('email already exists!');
   });
 
   it('should throw an error if the constraint is not valid', async () => {
@@ -70,7 +70,7 @@ describe('UniqueDecorator', () => {
       } as TestValidationArguments);
       throw new Error('Expected an error to be thrown!');
     } catch (err) {
-      expect(err.message).toBe('Model invalidModel is not exist');
+      expect(err.message).toBe('Model invalidModel does not exist');
     }
   });
 });

--- a/apps/backend/src/shared/decorators/unique/unique.decorator.ts
+++ b/apps/backend/src/shared/decorators/unique/unique.decorator.ts
@@ -18,7 +18,7 @@ export class UniqueConstraint implements ValidatorConstraintInterface {
 
     if (!value || !model) return false;
 
-    if (!this.prisma[model]) throw new Error(`Model ${model} is not exist`);
+    if (!this.prisma[model]) throw new Error(`Model ${model} does not exist`);
 
     const record = await (this.prisma[model] as any).findUnique({
       where: {
@@ -30,7 +30,7 @@ export class UniqueConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage(args: ValidationArguments) {
-    return `${args.property} is already exists!`;
+    return `${args.property} already exists!`;
   }
 }
 


### PR DESCRIPTION
Correct a few typos I've spotted in errors triggered by decorators.