### PR TITLE
docs: rename LICENSE.txt to LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Don't forget to give the project a star ⭐!
 
 ## 📝 License
 
-Distributed under the MIT License. See `LICENSE.txt` for more information.
+Distributed under the MIT License. See `LICENSE` for more information.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
Fixes #542 

I have change "LICENSE.txt" to "LICENSE", removing the suffix as you said.