### PR TITLE
fix: resolve cache persistence issue for deleted URLs

### DIFF
--- a/apps/backend/src/core/links/links.controller.spec.ts
+++ b/apps/backend/src/core/links/links.controller.spec.ts
@@ -10,6 +10,7 @@ import { SortOrder } from '../../shared/enums/sort-order.enum';
 import { LinksService } from './links.service';
 import { LinksController } from './links.controller';
 import { IFindAllOptions } from '../entity.service';
+import { AppCacheService } from '../../cache/cache.service';
 
 describe('LinksController', () => {
   let app: INestApplication;
@@ -41,6 +42,12 @@ describe('LinksController', () => {
             findAll: jest.fn().mockResolvedValue(MOCK_FIND_ALL_RESULT),
             findBy: jest.fn().mockResolvedValue(MOCKED_LINKS[0]),
             delete: jest.fn().mockResolvedValue(MOCKED_LINKS[0]),
+          },
+        },
+        {
+          provide: AppCacheService,
+          useValue: {
+            del: jest.fn(),
           },
         },
       ],

--- a/apps/backend/src/core/links/links.controller.ts
+++ b/apps/backend/src/core/links/links.controller.ts
@@ -49,10 +49,7 @@ export class LinksController {
       throw new UnauthorizedException();
     }
 
-    await Promise.all([
-        this.cacheService.del(link.key),
-        this.linksService.delete(id)
-    ]);
+    await Promise.all([this.cacheService.del(link.key), this.linksService.delete(id)]);
 
     return link;
   }

--- a/apps/backend/src/core/links/links.controller.ts
+++ b/apps/backend/src/core/links/links.controller.ts
@@ -49,8 +49,11 @@ export class LinksController {
       throw new UnauthorizedException();
     }
 
-    await this.cacheService.del(link.key);
+    await Promise.all([
+        this.cacheService.del(link.key),
+        this.linksService.delete(id)
+    ]);
 
-    return this.linksService.delete(id);
+    return link;
   }
 }


### PR DESCRIPTION
Resolving #741 
When a URL is deleted make sure to also invalidate the matching cache entry so the link is no longer accessible.